### PR TITLE
Allow specifying configgin version and use base_image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
-ARG registry
-FROM ${registry}/splatform/os-image-sle12
+ARG base_image
+FROM ${base_image}
 
 # Install RVM & Ruby 2.3.1
 RUN zypper -n in --force-resolution libopenssl-devel \
@@ -12,7 +12,9 @@ RUN wget -O /usr/bin/dumb-init https://github.com/Yelp/dumb-init/releases/downlo
         && chmod +x /usr/bin/dumb-init
 
 # Install configgin
-RUN /bin/bash -c "source /usr/local/rvm/scripts/rvm && gem install configgin"
+# Putting this ARG to the top of the file mysteriously makes it always empty :|
+ARG configgin_version
+RUN /bin/bash -c "source /usr/local/rvm/scripts/rvm && gem install configgin ${configgin_version:+--version=${configgin_version}}"
 
 # Install additional dependencies
 RUN zypper -n in gettext-tools jq rsync


### PR DESCRIPTION
This is one step of reverting the unifying of the openSUSE and SLE fissile stemcell repo https://github.com/SUSE/bosh-linux-stemcell-builder-ci/pull/3.

It also uses the base_image instead of registry to be more in pair with the openSUSE repo.

Jonathan