### PR TITLE
Bump configgin from 0.18.5 to 0.18.6

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -19,7 +19,7 @@ RUN wget -O /usr/bin/dumb-init https://github.com/Yelp/dumb-init/releases/downlo
 
 # Install configgin
 # The configgin version is hardcoded here so a commit is generated when the version is bumped.
-RUN /bin/bash -c "source /usr/local/rvm/scripts/rvm && gem install configgin --version=0.18.5"
+RUN /bin/bash -c "source /usr/local/rvm/scripts/rvm && gem install configgin --version=0.18.6"
 
 # Install additional dependencies
 RUN zypper -n in jq rsync fuse


### PR DESCRIPTION
This adds code to check with the statefulset for the role for the proper image.
The result is used to filter the set of pods.
Required to ignore pods running the old image during an upgrade.
Required to not wait on such pods to be ready, they can't be.