### PR TITLE
Bump configgin from 0.18.7 to 0.18.8

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -19,7 +19,7 @@ RUN wget -O /usr/bin/dumb-init https://github.com/Yelp/dumb-init/releases/downlo
 
 # Install configgin
 # The configgin version is hardcoded here so a commit is generated when the version is bumped.
-RUN /bin/bash -c "source /usr/local/rvm/scripts/rvm && gem install configgin --version=0.18.7"
+RUN /bin/bash -c "source /usr/local/rvm/scripts/rvm && gem install configgin --version=0.18.8"
 
 # Install additional dependencies
 RUN zypper -n in jq rsync fuse


### PR DESCRIPTION
This pulls in a change to the code to make pods restart when the property they pull in from a BOSH link changes.  It now correctly causes restarts when the link they pull from is not named the same as the job that provides that link.

See also: https://github.com/cloudfoundry-incubator/configgin/pull/104